### PR TITLE
Change peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,12 @@
     "outputName": "junit.xml"
   },
   "dependencies": {
-    "@guardtime/common": "^1.0.3",
     "abortcontroller-polyfill": "^1.5.0",
-    "big-integer": "^1.6.48",
     "node-fetch": "^2.6.1",
     "uuid": "^8.3.1"
+  },
+  "peerDependencies": {
+    "@guardtime/common": "^1.0.3",
+    "big-integer": "^1.6.48"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
     "webpack": "^5.3.2",
     "webpack-cli": "^4.1.0",
     "typedoc": "^0.19.2",
-    "license-checker-webpack-plugin": "^0.1.5"
+    "license-checker-webpack-plugin": "^0.1.5",
+    "@guardtime/common": "^1.0.3",
+    "big-integer": "^1.6.48"
   },
   "jest-junit": {
     "outputDirectory": "./coverage",

--- a/src/common/signature/verification/rule/InputHashAlgorithmVerificationRule.ts
+++ b/src/common/signature/verification/rule/InputHashAlgorithmVerificationRule.ts
@@ -50,7 +50,7 @@ export class InputHashAlgorithmVerificationRule extends VerificationRule {
 
     const inputHash: DataHash = signature.getInputHash();
 
-    if (documentHash.hashAlgorithm !== inputHash.hashAlgorithm) {
+    if (!documentHash.hashAlgorithm.isEqual(inputHash.hashAlgorithm)) {
       console.debug(
         `Wrong input hash algorithm. Expected ${documentHash.hashAlgorithm}, found ${inputHash.hashAlgorithm}.`
       );


### PR DESCRIPTION
Add @guardtime/common and big-integer library as peer dependency to prevent issues with building libraries.